### PR TITLE
Final work before 1.1 release

### DIFF
--- a/TWTValidation/Validators/Value Validators/TWTStringValidator.m
+++ b/TWTValidation/Validators/Value Validators/TWTStringValidator.m
@@ -699,7 +699,7 @@
 - (NSCharacterSet *)invertedCharacterSet
 {
     if (!_invertedCharacterSet) {
-        self.invertedCharacterSet = [self.characterSet.invertedSet copy];
+        self.invertedCharacterSet = self.characterSet.invertedSet;
     }
 
     return _invertedCharacterSet;


### PR DESCRIPTION
Lazily initialize `TWTWildcardPatternStringValidator`'s `predicate` property. Also use accessors to set properties in lazy initializers.
